### PR TITLE
Use the vanilla barrel naming pattern for canisters

### DIFF
--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -363,7 +363,7 @@ crushed-zinc=Zerkleinertes Zink
 log=Baumstamm
 
 empty-gas-canister=Leerer Gaskanister
-filled-methanol-gas-canister=Gefüllter Methanol Kanister
+methanol-gas-canister=Gefüllter Methanol Kanister
 
 [item-description]
 coke="Bessere Kohle"

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -366,7 +366,7 @@ crushed-quartz=Crushed quartz
 powdered-quartz=Powdered quartz
 
 empty-gas-canister=Empty gas canister
-filled-methanol-gas-canister=Filled methanol canister
+methanol-gas-canister=Filled methanol canister
 
 fill-can=__1__ canister
 empty-fuel-canister=Empty fuel canister

--- a/locale/ja/locale.cfg
+++ b/locale/ja/locale.cfg
@@ -364,7 +364,7 @@ crushed-zinc=Crushed Zinc
 log=Log
 
 empty-gas-canister=Empty gas canister
-filled-methanol-gas-canister=Filled methanol canister
+methanol-gas-canister=Filled methanol canister
 
 [item-description]
 coke=Improved coal fuel

--- a/locale/ru/locale.cfg
+++ b/locale/ru/locale.cfg
@@ -360,7 +360,7 @@ crushed-zinc=Дроблёный цинк
 log=Бревно
 
 empty-gas-canister=Пустой баллон
-filled-methanol-gas-canister=Баллон метанола
+methanol-gas-canister=Баллон метанола
 
 [item-description]
 coke=Улучшенное угольное топливо

--- a/locale/zh-CN/pycoalprocessing.cfg
+++ b/locale/zh-CN/pycoalprocessing.cfg
@@ -378,7 +378,7 @@ crushed-zinc=粉碎的锌矿石
 log=原木
 
 empty-gas-canister=空的气罐
-filled-methanol-gas-canister=甲醇罐
+methanol-gas-canister=甲醇罐
 
 [item-description]
 coke=提高煤燃烧率，同时也是重要的化工原料

--- a/prototypes/fluids/refsyngas.lua
+++ b/prototypes/fluids/refsyngas.lua
@@ -40,7 +40,7 @@ RECIPE {
     energy_required = 2,
     ingredients = {
         {type = "fluid", name = "syngas", amount = 100},
-        {type = "item", name = "filled-methanol-gas-canister", amount = 1}
+        {type = "item", name = "methanol-gas-canister", amount = 1}
     },
     results = {
         {type = "fluid", name = "refsyngas", amount = 100},

--- a/prototypes/items/canister.lua
+++ b/prototypes/items/canister.lua
@@ -41,7 +41,7 @@ RECIPE {
         {type = "item", name = "empty-gas-canister", amount = 1}
     },
     results = {
-        {type = "item", name = "filled-methanol-gas-canister", amount = 1}
+        {type = "item", name = "methanol-gas-canister", amount = 1}
     },
     icon = "__pycoalprocessinggraphics__/graphics/icons/canister.png",
     icon_size = 32
@@ -56,7 +56,7 @@ RECIPE {
     enabled = false,
     energy_required = 0.2,
     ingredients = {
-        {type = "item", name = "filled-methanol-gas-canister", amount = 1}
+        {type = "item", name = "methanol-gas-canister", amount = 1}
     },
     results = {
         {type = "item", name = "empty-gas-canister", amount = 1},
@@ -70,7 +70,7 @@ RECIPE {
 
 ITEM {
     type = "item",
-    name = "filled-methanol-gas-canister",
+    name = "methanol-gas-canister",
     icon = "__pycoalprocessinggraphics__/graphics/icons/canister.png",
     icon_size = 32,
     flags = {},

--- a/prototypes/recipes/fuel-canister-recipes.lua
+++ b/prototypes/recipes/fuel-canister-recipes.lua
@@ -33,7 +33,7 @@ for f, fluid in pairs(data.raw.fluid) do
 
         ITEM {
             type = "item",
-            name = "filled-canister-" .. fluid.name,
+            name = fluid.name .. "-canister",
             localised_name = {"item-name.fill-can", fluid.localised_name or {"fluid-name." .. fluid.name}},
             icons = {
                 {icon = "__pycoalprocessinggraphics__/graphics/icons/jerry-can.png", icon_size = 64},
@@ -58,7 +58,7 @@ for f, fluid in pairs(data.raw.fluid) do
 
         RECIPE {
             type = "recipe",
-            name = "fill-canister-" .. fluid.name,
+            name = "fill-" .. fluid.name .. "-canister",
             localised_name = {"recipe-name.fill-can", fluid.localised_name or {"fluid-name." .. fluid.name}},
             category = "crafting-with-fluid",
             enabled = false,
@@ -68,7 +68,7 @@ for f, fluid in pairs(data.raw.fluid) do
                 {type = "item", name = "empty-fuel-canister", amount = 1}
             },
             results = {
-                {type = "item", name = "filled-canister-" .. fluid.name, amount = 1}
+                {type = "item", name = fluid.name .. "-canister", amount = 1}
             },
             ignore_for_dependencies = true
             --icon = "__pycoalprocessinggraphics__/graphics/icons/canister.png",
@@ -78,13 +78,13 @@ for f, fluid in pairs(data.raw.fluid) do
 
         RECIPE {
             type = "recipe",
-            name = "empty-canister-" .. fluid.name,
+            name = "empty-" .. fluid.name .. "-canister",
             localised_name = {"recipe-name.empty-can", fluid.localised_name or {"fluid-name." .. fluid.name}},
             category = "crafting-with-fluid",
             enabled = false,
             energy_required = 0.2,
             ingredients = {
-                {type = "item", name = "filled-canister-" .. fluid.name, amount = 1}
+                {type = "item", name = fluid.name .. "-canister", amount = 1}
             },
             results = {
                 {type = "fluid", name = fluid.name, amount = fuel_amount},


### PR DESCRIPTION
Apply the vanilla barrel naming pattern to canisters.

Filled canister items : fluid_name .. "-canister"
Empty canister item: "empty-canister" (This was fine)
Filling recipe:  "fill-" .. fluid_name .. "-canister"
Emptying recipe:  "empty-" .. fluid_name .. "-canister"

Has the version with those names already been released? (-->Are migrations required?)