### PR TITLE
Crystal mines and other miners no longer take simik related modules

### DIFF
--- a/prototypes/buildings/borax-mine-mk02.lua
+++ b/prototypes/buildings/borax-mine-mk02.lua
@@ -99,7 +99,7 @@ ENTITY {
     module_specification = {
         module_slots = 2
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 3,
     energy_source = {
         type = "electric",

--- a/prototypes/buildings/borax-mine-mk03.lua
+++ b/prototypes/buildings/borax-mine-mk03.lua
@@ -98,7 +98,7 @@ ENTITY {
     module_specification = {
         module_slots = 3
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 4,
     energy_source = {
         type = "electric",

--- a/prototypes/buildings/borax-mine-mk04.lua
+++ b/prototypes/buildings/borax-mine-mk04.lua
@@ -97,7 +97,7 @@ ENTITY {
     module_specification = {
         module_slots = 4
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 5,
     energy_source = {
         type = "electric",

--- a/prototypes/buildings/borax-mine.lua
+++ b/prototypes/buildings/borax-mine.lua
@@ -98,7 +98,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 2,
     energy_source = {
         type = "electric",

--- a/prototypes/buildings/niobium-mine.lua
+++ b/prototypes/buildings/niobium-mine.lua
@@ -103,7 +103,7 @@ ENTITY {
     module_specification = {
         module_slots = 4
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 1,
     energy_source = {
         type = "burner",


### PR DESCRIPTION
This is done by making these modules increase pollution output, and forbidding pollution modules in these miners.