### PR TITLE
Made cooling-water hidden from player crafting instead of hidden.

### DIFF
--- a/prototypes/recipes/recipes.lua
+++ b/prototypes/recipes/recipes.lua
@@ -157,7 +157,7 @@ RECIPE {
 RECIPE {
     type = "recipe",
     name = "cooling-water",
-    hidden = true,
+    hide_from_player_crafting = true,
     category = "cooling",
     enabled = false,
     energy_required = 4,


### PR DESCRIPTION
As per KiwiHawk's suggestion.

(partially) resolves pyanodon/pybugreports#120