### PR TITLE
Added Crystal Mine circuit connectivity

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -16,6 +16,10 @@ require('prototypes/item-groups')
 require('prototypes/recipe-categories')
 -- ))
 
+-- (( Circuit Connector Definitions )) --
+require("prototypes/circuit-connector-definitions")
+-- ))
+
 -- (( Technology ))--
 require('prototypes/technologies/coal-processing-1')
 require('prototypes/technologies/coal-processing-2')

--- a/prototypes/buildings/borax-mine-mk02.lua
+++ b/prototypes/buildings/borax-mine-mk02.lua
@@ -115,6 +115,13 @@ ENTITY {
         width = 12,
         height = 12
     },
+
+    require ("__pycoalprocessing__/prototypes/circuit-connector-definitions-pycp"),
+
+    circuit_wire_connection_points = borax_mine_connector_definitions.points,
+    circuit_connector_sprites = borax_mine_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+    
     graphics_set = {
         animation = dry_graphics
     },

--- a/prototypes/buildings/borax-mine-mk02.lua
+++ b/prototypes/buildings/borax-mine-mk02.lua
@@ -115,13 +115,9 @@ ENTITY {
         width = 12,
         height = 12
     },
-
-    require ("__pycoalprocessing__/prototypes/circuit-connector-definitions-pycp"),
-
-    circuit_wire_connection_points = borax_mine_connector_definitions.points,
-    circuit_connector_sprites = borax_mine_connector_definitions.sprites,
+    circuit_wire_connection_points = circuit_connector_definitions["borax-mine-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["borax-mine-mkxx"].sprites,
     circuit_wire_max_distance = default_circuit_wire_max_distance,
-    
     graphics_set = {
         animation = dry_graphics
     },

--- a/prototypes/buildings/borax-mine-mk03.lua
+++ b/prototypes/buildings/borax-mine-mk03.lua
@@ -114,13 +114,9 @@ ENTITY {
         width = 12,
         height = 12
     },
-
-    require ("__pycoalprocessing__/prototypes/circuit-connector-definitions-pycp"),
-
-    circuit_wire_connection_points = borax_mine_connector_definitions.points,
-    circuit_connector_sprites = borax_mine_connector_definitions.sprites,
+    circuit_wire_connection_points = circuit_connector_definitions["borax-mine-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["borax-mine-mkxx"].sprites,
     circuit_wire_max_distance = default_circuit_wire_max_distance,
-    
     graphics_set = {
         animation = dry_graphics
     },

--- a/prototypes/buildings/borax-mine-mk03.lua
+++ b/prototypes/buildings/borax-mine-mk03.lua
@@ -114,6 +114,13 @@ ENTITY {
         width = 12,
         height = 12
     },
+
+    require ("__pycoalprocessing__/prototypes/circuit-connector-definitions-pycp"),
+
+    circuit_wire_connection_points = borax_mine_connector_definitions.points,
+    circuit_connector_sprites = borax_mine_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+    
     graphics_set = {
         animation = dry_graphics
     },

--- a/prototypes/buildings/borax-mine-mk04.lua
+++ b/prototypes/buildings/borax-mine-mk04.lua
@@ -113,6 +113,13 @@ ENTITY {
         width = 12,
         height = 12
     },
+
+    require ("__pycoalprocessing__/prototypes/circuit-connector-definitions-pycp"),
+
+    circuit_wire_connection_points = borax_mine_connector_definitions.points,
+    circuit_connector_sprites = borax_mine_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+    
     graphics_set = {
         animation = dry_graphics
     },

--- a/prototypes/buildings/borax-mine-mk04.lua
+++ b/prototypes/buildings/borax-mine-mk04.lua
@@ -113,13 +113,9 @@ ENTITY {
         width = 12,
         height = 12
     },
-
-    require ("__pycoalprocessing__/prototypes/circuit-connector-definitions-pycp"),
-
-    circuit_wire_connection_points = borax_mine_connector_definitions.points,
-    circuit_connector_sprites = borax_mine_connector_definitions.sprites,
+    circuit_wire_connection_points = circuit_connector_definitions["borax-mine-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["borax-mine-mkxx"].sprites,
     circuit_wire_max_distance = default_circuit_wire_max_distance,
-    
     graphics_set = {
         animation = dry_graphics
     },

--- a/prototypes/buildings/borax-mine.lua
+++ b/prototypes/buildings/borax-mine.lua
@@ -113,13 +113,9 @@ ENTITY {
         width = 12,
         height = 12
     },
-
-    require ("__pycoalprocessing__/prototypes/circuit-connector-definitions-pycp"),
-
-    circuit_wire_connection_points = borax_mine_connector_definitions.points,
-    circuit_connector_sprites = borax_mine_connector_definitions.sprites,
+    circuit_wire_connection_points = circuit_connector_definitions["borax-mine-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["borax-mine-mkxx"].sprites,
     circuit_wire_max_distance = default_circuit_wire_max_distance,
-
     graphics_set = {
         animation = dry_graphics
     },

--- a/prototypes/buildings/borax-mine.lua
+++ b/prototypes/buildings/borax-mine.lua
@@ -113,6 +113,13 @@ ENTITY {
         width = 12,
         height = 12
     },
+
+    require ("__pycoalprocessing__/prototypes/circuit-connector-definitions-pycp"),
+
+    circuit_wire_connection_points = borax_mine_connector_definitions.points,
+    circuit_connector_sprites = borax_mine_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+
     graphics_set = {
         animation = dry_graphics
     },

--- a/prototypes/circuit-connector-definitions-pycp.lua
+++ b/prototypes/circuit-connector-definitions-pycp.lua
@@ -1,0 +1,13 @@
+-- Holds circuit connection definitions for PyAL entities.
+-- variation counts from 0 (Python-like).
+
+borax_mine_connector_definitions = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 26, main_offset = util.by_pixel(-40, 85), shadow_offset = util.by_pixel(-46, 97), show_shadow = false }, 
+    { variation = 26, main_offset = util.by_pixel(-40, 85), shadow_offset = util.by_pixel(-46, 97), show_shadow = false },
+    { variation = 26, main_offset = util.by_pixel(-40, 85), shadow_offset = util.by_pixel(-46, 97), show_shadow = false },
+    { variation = 26, main_offset = util.by_pixel(-40, 85), shadow_offset = util.by_pixel(-46, 97), show_shadow = false }
+  }
+)

--- a/prototypes/circuit-connector-definitions.lua
+++ b/prototypes/circuit-connector-definitions.lua
@@ -1,7 +1,8 @@
--- Holds circuit connection definitions for PyAL entities.
+-- Adds circuit connection definitions for PyCP entities to the pre-existing global table
+-- for base-game implementation details, see https://github.com/wube/factorio-data/blob/ed3d12197fbbe63fcd19c0eb23bc826cea44410f/core/lualib/circuit-connector-sprites.lua#L101
 -- variation counts from 0 (Python-like).
 
-borax_mine_connector_definitions = circuit_connector_definitions.create
+circuit_connector_definitions["borax-mine-mkxx"] = circuit_connector_definitions.create
 (
   universal_connector_template,
   {--Directions are up, right, down, left.


### PR DESCRIPTION
This PR adds circuit connectivity to all four Mks. of Crystal Mine, allowing them to output available resources as a signal. These pull from a new `circuit-connector-definitions` file in the parent directory.