### PR TITLE
Bump size of vanilla ores in the Py recommended present, to match the other ores.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.1.3
+Date: 2023-X-X
+  Changes:
+    - bumped vanilla ore sizes in recommended preset for freeplay
+---------------------------------------------------------------------------------------------------
 Version: 2.1.2
 Date: 2023-4-16
   Changes:
@@ -30,7 +35,7 @@ Version: 2.0.7
 Date: 2023-1-31
   Changes:
     - reworked the pywiki
-    - fixed that certian machines were blocking prod modules, even though they had prod recipes
+    - fixed that certain machines were blocking prod modules, even though they had prod recipes
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.6
 Date: 2023-1-5

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -785,7 +785,7 @@ polluted-ground-burnt=Burnt polluted ground
 py-recommended=Pyanodon recommended
 
 [map-gen-preset-description]
-py-recommended=These are the recommend settings for playing Pyanodon's mods without Resource Spawner Overhaul active. Resources patches are slightly smaller, very spaced out, and much richer.\nEnemies and pollution are disabled, technology queue is always enabled. Cliffs and water are lessened, slightly.
+py-recommended=These are the recommend settings for playing Pyanodon's mods without Resource Spawner Overhaul active. Resources patches are slightly smaller, very spaced out, and much richer.\nEnemies and pollution are disabled, technology queue is always enabled. Cliffs and water are lessened, slightly. Re-roll the map seed until starting patches don't overlap for best results.
 
 [tooltip-category]
 shot=Edible

--- a/prototypes/map-gen-presets.lua
+++ b/prototypes/map-gen-presets.lua
@@ -29,10 +29,6 @@ local rocks = {
 }
 --[[ if it comes up
 local non_rocks = {
-    ["iron-ore"] = true,
-    ["copper-ore"] = true,
-    ["stone"] = true,
-    ["uranium-ore"] = true,
     ["borax"] = true,
     ["niobium"] = true,
     ["molybdenum-ore"] = true,
@@ -53,6 +49,13 @@ local non_rocks = {
     ["antimonium"] = true,
 }
 ]]--
+
+local vanilla_resources = {
+    ["iron-ore"] = true,
+    ["copper-ore"] = true,
+    ["stone"] = true,
+    ["uranium-ore"] = true,
+}
 
 
 
@@ -130,15 +133,41 @@ local rock_values = {
         richness = 1.0
     }
 }
+local vanilla_values = {
+    ["rich-resources"] = {
+        richness = 2.0
+    },
+    ["rail-world"] = {
+        frequency = 0.33,
+        size = 3.0
+    },
+    ["py-recommended"] = {
+        frequency = 0.33,
+        richness = 6,
+        size = 1.5
+    },
+    ["ribbon-world"] = {
+        frequency = 3.0,
+        size = 0.5,
+        richness = 2.0
+    }
+}
 
 for name in pairs(data.raw["autoplace-control"]) do
     if blacklist[name] then goto continue end
     local is_rock = rocks[name]
+    local is_vanilla = vanilla_resources[name]
     for preset_name, preset_data in pairs(mapgens) do
         local control = preset_data["basic_settings"] and preset_data["basic_settings"]["autoplace_controls"]
         -- If someone has already modified it, I see no reason to change it
         if control and not control[name] then
-            control[name] = is_rock and rock_values[preset_name] or non_rock_values[preset_name]
+            if is_rock then
+                control[name] = rock_values[preset_name]
+            elseif is_vanilla then
+                control[name] = vanilla_values[preset_name]
+            else
+                control[name] = non_rock_values[preset_name]
+            end
         end
     end
     ::continue::


### PR DESCRIPTION
As mentioned in pyanodon/pybugreports#202, the vanilla ores are much less rich than the new ores in the Py recommended settings. In particular for stone, but also for the other ores, this means you run out very quickly compared to the other ores which can easily be 10 times richer or more. I've increased the size of vanilla ores from 0.75 to 2 in the preset.

I've generated 3 maps and found the starter patch and the closest non-starter patch for all starting ores. "copper X, Y" means the starting patch has size X and the closest non-starter patch has size Y. X+Y means there are two patches of this type, of size X and Y.

### Seed 3186172809
Before fix:
- copper 491k, 15M
- coal 35M, 193M
- iron 1M, 2.3M + 8.8M
- native flora 933k, 48M
- stone 308k + 288k, 4.1M
- alu 846k, 58M

After fix:
- copper 1.3M, 43M
- stone 731k + 687k, 10M
- iron 2.4M, 7.2M + 22M

### Seed 3199723357
Before fix:
- copper 504k, 14M + 8M
- stone 437k, 2.2M + 1.4M
- iron 662k, 10M
- coal 39M, 178M
- native flora 834k, 95M
- alu 721k, 52M

After fix:
- copper 1.1M
- stone 1.3M, 6M + 3.6M
- iron 1.7M, 19M

### Seed 1916395336
Before fix:
- copper 504k, 11M
- coal 31M, 169M
- iron 662k, 26M
- native flora 635k, 96M
- stone 127k, 3.4M
- alu 681k, 112M

After fix:
- copper 1.3M, 25M
- stone 330k, 9M
- iron 1.7M, 67M
