### PR TITLE
Enforce ingredient limit for Burner 2s and 3s

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 2.1.4
 Date: ?
   Changes:
     - Fix crash with fluid fluid fuel value formatting. (https://github.com/pyanodon/pybugreports/issues/307)
+    - Enforced solid ingredient limit for Burner Assembler 2 and 3
 ---------------------------------------------------------------------------------------------------
 Version: 2.1.3
 Date: 2023-7-25

--- a/prototypes/updates/entity-updates.lua
+++ b/prototypes/updates/entity-updates.lua
@@ -72,7 +72,7 @@ data.raw['assembling-machine']['assembling-machine-1'].fluid_boxes = data.raw['a
 table.insert(data.raw['assembling-machine']['assembling-machine-1'].crafting_categories, "crafting-with-fluid")
 
 --modify assembly machine 2
-data.raw['assembling-machine']['assembling-machine-2'].ingredient_count = 6
+data.raw['assembling-machine']['assembling-machine-2'].ingredient_count = 4
 data.raw['assembling-machine']['assembling-machine-2'].crafting_speed = 2
 data.raw['assembling-machine']['assembling-machine-2'].energy_source = table.deep_copy(burner)
 table.insert(data.raw['assembling-machine']['assembling-machine-2'].energy_source.fuel_categories, "jerry")
@@ -80,7 +80,7 @@ data.raw['assembling-machine']['assembling-machine-2'].allowed_effects = {}
 data.raw['assembling-machine']['assembling-machine-2'].module_specification.module_slots = 0
 
 --modify assembly machine 3
---data.raw['assembling-machine']['assembling-machine-3'].ingredient_count = 5
+data.raw['assembling-machine']['assembling-machine-3'].ingredient_count = 5
 data.raw['assembling-machine']['assembling-machine-3'].crafting_speed = 4
 data.raw['assembling-machine']['assembling-machine-3'].energy_source = table.deep_copy(burner)
 table.insert(data.raw['assembling-machine']['assembling-machine-3'].energy_source.fuel_categories, "jerry")


### PR DESCRIPTION
At present, the pY Codex states that Burner Assembler 2s have a limit of four solid ingredients in their accepted recipes, while Burner 3s can accept up to five. I originally took this as read, but noticed while planning my Hub blocks that the pY-Sinkhole (with five solid ingredients) can be crafted in a Burner 2, which shouldn't be possible. After seeing [this Reddit post](https://www.reddit.com/r/factorio/comments/162iez0/omg_its_like_some_sort_of_mall_it_was_a_big_day/), I realised this limit wasn't being enforced as I had been led to believe.
This PR reduces the ingredient limit for Burner 2s from six to four and enforces a limit of five for the Burner 3, which was previously uncapped, thus directing the player to use Automated Factories as (what I currently believe) is intended. If the original higher caps are intended, the Codex text should instead be updated to reflect this.