### PR TITLE
Align wpu output visually to a grid square.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ Date: ?
     - Fixed DiscoScience integration. Resolves https://github.com/pyanodon/pybugreports/issues/774
     - Fixed 1,800,000/s max flow rate instead of 30,000/s. Resolves https://github.com/pyanodon/pybugreports/issues/772
     - Fixed that the fish turbine could not be hand-craftable through the log route. Resolves https://github.com/pyanodon/pybugreports/issues/667
+    - Align wood processing unit output to a grid square.
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.26
 Date: 2024-11-29

--- a/prototypes/buildings/wpu.lua
+++ b/prototypes/buildings/wpu.lua
@@ -44,7 +44,7 @@ for i = 1, 4 do
         minable = {mining_time = 1, result = name},
         fast_replaceable_group = "wpu",
         max_health = 800 * i,
-        vector_to_place_result = {0.0, 3.01},
+        vector_to_place_result = {-0.5, 3.1},
         corpse = "medium-remnants",
         dying_explosion = "medium-explosion",
         collision_box = {{-2.8, -2.8}, {2.8, 2.8}},


### PR DESCRIPTION
Moves the output arrow one tile over so that it's more obvious where the output goes. 