### PR TITLE
Disable luacheck

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,10 +1,8 @@
 on:
   push:
     branches:
-    - master
   pull_request:
     branches:
-    - master
 name: Luacheck
 jobs:
   lint:


### PR DESCRIPTION
luacheck currently expects 1.x nomenclature and doesn't understand globals, this is useless to us and fails our tests for invalid reasons

Other repositories have it disabled by pointing it at master/main - whichever the repo DOESN'T use, but this is unnecessarily confusing.