### PR TITLE
Re-enabled achievements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ Date: ?
     - Fixed generator equipment manager only filling the first slot. Resolves https://github.com/pyanodon/pybugreports/issues/1085
     - Fixed Diet beacon crash on changing frequency. Resolves https://github.com/pyanodon/pybugreports/issues/1114
     - Fixed Bulk Inserter 1 and 2 technologies not having the correct prerequesites and dependants. Resolves https://github.com/pyanodon/pybugreports/issues/1086 and https://github.com/pyanodon/pybugreports/issues/1099
+    - Fixed that launching a rocket would trigger the Pyrrhic Victory achievement. This incidentally enables some other achievements that were disabled by an old "temporary" fix.
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.39
 Date: 2025-07-20

--- a/data.lua
+++ b/data.lua
@@ -164,7 +164,7 @@ require "prototypes/buildings/beacon"
 require "prototypes/buildings/diet-beacon"
 require "prototypes/buildings/lab"
 
---require 'prototypes/achievements'
+require 'prototypes/achievements'
 require "prototypes/logo"
 require "prototypes/menu-simulations"
 

--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -788,7 +788,7 @@ glassworks-mk03=Gebäude zur Herstellung von Glasbehältnissen und Glasscheiben.
 glassworks-mk04=Gebäude zur Herstellung von Glasbehältnissen und Glasscheiben. Funktioniert mit jeder Flüssigkeit mit einem Brennstoffwert
 
 [achievement-name]
-smoke-me-a-kipper-i-will-be-back-for-breakfast=Pyrrhic victory
+pyrrhic-victory=Pyrrhic victory
 empire-of-dirt=Königreich des Drecks
 dust-to-dust=Staub um Staub
 what-do-you-mean-i-didnt-win-the-game=Was soll das heißen, habe ich das Spiel nicht gewonnen?
@@ -804,7 +804,7 @@ now-i-am-become-death=Now I am become death
 roids-1=Der erste Schritt
 
 [achievement-description]
-smoke-me-a-kipper-i-will-be-back-for-breakfast=Ein Sieg, der dem Sieger einen so verheerenden Schaden zufügt, dass er einer Niederlage gleichkommt.
+pyrrhic-victory=Ein Sieg, der dem Sieger einen so verheerenden Schaden zufügt, dass er einer Niederlage gleichkommt.
 empire-of-dirt=Produziere 1 Millionen Dreck
 dust-to-dust=Produziere 1 Millionen Asche
 what-do-you-mean-i-didnt-win-the-game=Schicke einer Tholins-Kapsel ins All.

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -776,7 +776,7 @@ glassworks-mk04=Building that produces containers and sheets made of glass. Work
 co2-absorber=Carbon capture for the conscientious colonizer.
 
 [achievement-name]
-smoke-me-a-kipper-i-will-be-back-for-breakfast=Pyrrhic victory
+pyrrhic-victory=Pyrrhic victory
 empire-of-dirt=Empire of dirt
 dust-to-dust=Dust to dust
 what-do-you-mean-i-didnt-win-the-game=What do you mean I didn't win the game?
@@ -792,7 +792,7 @@ now-i-am-become-death=Now I am become death
 roids-1=The first step
 
 [achievement-description]
-smoke-me-a-kipper-i-will-be-back-for-breakfast=A victory that inflicts such a devastating toll on the victor that it is tantamount to defeat.
+pyrrhic-victory=A victory that inflicts such a devastating toll on the victor that it is tantamount to defeat.
 empire-of-dirt=Produce 1 million soil.
 dust-to-dust=Produce 1 million ash.
 what-do-you-mean-i-didnt-win-the-game=Launch a tholins capsule into space.

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -788,7 +788,7 @@ glassworks-mk03=Bâtiment qui produit des récipients et des plaques de verre. F
 glassworks-mk04=Bâtiment qui produit des récipients et des plaques de verre. Fonctionne avec n'importe quel fluide ayant une valeur de carburant.
 
 [achievement-name]
-smoke-me-a-kipper-i-will-be-back-for-breakfast=Victoire pyrrhique
+pyrrhic-victory=Victoire pyrrhique
 empire-of-dirt=L'empire de la poussière
 dust-to-dust=De poussière tu retournera à la poussière
 what-do-you-mean-i-didnt-win-the-game=Comment ça je n'ai pas finis la partie?
@@ -804,7 +804,7 @@ now-i-am-become-death=Je suis devenu la Mort
 roids-1=Le premier pas
 
 [achievement-description]
-smoke-me-a-kipper-i-will-be-back-for-breakfast=Une victoire obtenue au prix de pertes si lourdes pour le vainqueur qu'elle équivaut quasiment à une défaite.
+pyrrhic-victory=Une victoire obtenue au prix de pertes si lourdes pour le vainqueur qu'elle équivaut quasiment à une défaite.
 empire-of-dirt=Produit 1 million d'unité de sol.
 dust-to-dust=Produit 1 million d'unité de cendres.
 what-do-you-mean-i-didnt-win-the-game=Lance une capsule à tholins dans l'espace.

--- a/locale/ru/locale.cfg
+++ b/locale/ru/locale.cfg
@@ -769,7 +769,7 @@ olefin-unit=Специальное строение, позволяющее пе
 co2_absorber=Превращает загрязнение в углекислый газ.
 
 [achievement-name]
-smoke-me-a-kipper-i-will-be-back-for-breakfast=Пиррова победа
+pyrrhic-victory=Пиррова победа
 empire-of-dirt=Империя грязи
 dust-to-dust=Пепел к пеплу
 what-do-you-mean-i-didnt-win-the-game=Что значит "я не выиграл игру"?
@@ -785,7 +785,7 @@ now-i-am-become-death=Теперь я сама смерть
 roids-1=Первый шаг
 
 [achievement-description]
-smoke-me-a-kipper-i-will-be-back-for-breakfast=Победа, которая наносит победителю столь сокрушительный урон, что это равносильно поражению.
+pyrrhic-victory=Победа, которая наносит победителю столь сокрушительный урон, что это равносильно поражению.
 empire-of-dirt=Произведите 1 миллион почвы.
 dust-to-dust=Произведите 1 миллион пепла.
 what-do-you-mean-i-didnt-win-the-game=Запустите в космос капсулу с толинами.

--- a/locale/uk/locale.cfg
+++ b/locale/uk/locale.cfg
@@ -751,7 +751,7 @@ glassworks-mk03=Будівля, що виробляє контейнери та 
 glassworks-mk04=Будівля, що виробляє контейнери та пластини зі скла. Працює з будь-якою рідиною із показником палива.
 
 [achievement-name]
-smoke-me-a-kipper-i-will-be-back-for-breakfast=Піррова перемога
+pyrrhic-victory=Піррова перемога
 empire-of-dirt=Імперія бруду
 dust-to-dust=Прах до праху
 what-do-you-mean-i-didnt-win-the-game=Що ти маєш на увазі, що я не виграв гру?
@@ -767,7 +767,7 @@ now-i-am-become-death=Тепер я став смертю
 roids-1=Перший крок
 
 [achievement-description]
-smoke-me-a-kipper-i-will-be-back-for-breakfast=Перемога, яка завдає такої руйнівної втрати переможцю, що це рівнозначно поразці.
+pyrrhic-victory=Перемога, яка завдає такої руйнівної втрати переможцю, що це рівнозначно поразці.
 empire-of-dirt=Видобудь 1 млн грунту.
 dust-to-dust=Видобудь 1 мільйон попелу.
 what-do-you-mean-i-didnt-win-the-game=Запустіть у космос капсулу толінів.

--- a/prototypes/achievements.lua
+++ b/prototypes/achievements.lua
@@ -15,14 +15,13 @@ data.raw["produce-per-hour-achievement"]["iron-throne-2"] = nil
 data.raw["produce-per-hour-achievement"]["iron-throne-3"] = nil
 data.raw["dont-use-entity-in-energy-production-achievement"]["solaris"] = nil
 data.raw["kill-achievement"]["steamrolled"] = nil
-data.raw["combat-robot-count"]["minions"] = nil
+data.raw["combat-robot-count-achievement"]["minions"] = nil
 data.raw["dont-use-entity-in-energy-production-achievement"]["steam-all-the-way"] = nil
 data.raw["dont-build-entity-achievement"]["raining-bullets"] = nil
 data.raw["dont-build-entity-achievement"]["logistic-network-embargo"] = nil
-data.raw["finish-the-game-achievement"]["no-time-for-chitchat"] = nil
-data.raw["finish-the-game-achievement"]["there-is-no-spoon"] = nil
+data.raw["complete-objective-achievement"]["no-time-for-chitchat"] = nil
+data.raw["complete-objective-achievement"]["there-is-no-spoon"] = nil
 
-data.raw["finish-the-game-achievement"]["smoke-me-a-kipper-i-will-be-back-for-breakfast"].icon = "__pycoalprocessinggraphics__/graphics/achievement/smoke-me-a-kipper-i-will-be-back-for-breakfast.png"
 
 -- ordering: 0, then a letter per mod, then a letter within the mod
 -- PyCP: a, PyIN: b, PyFE: c, PyPH: d, PyRO: e, PyHT: f, PyAL: g, PyAE: h
@@ -48,18 +47,28 @@ data:extend
         icon_size = 128,
         limited_to_one_game = true
     },
+    {
+        type = "complete-objective-achievement",
+        name = "pyrrhic-victory",
+        order = "0ac",
+        objective_condition = "game-finished",
+        icon = "__pycoalprocessinggraphics__/graphics/achievement/smoke-me-a-kipper-i-will-be-back-for-breakfast.png",
+        icon_size = 128,
+        limited_to_one_game = false
+    },
 }
 if mods.pypetroleumhandling then
+    data.raw["complete-objective-achievement"]["smoke-me-a-kipper-i-will-be-back-for-breakfast"] = nil -- replaced here with the meme achievement and above with pyrrhic victory
     data:extend {
         {
             type = "produce-achievement",
             name = "what-do-you-mean-i-didnt-win-the-game",
             order = "0da",
-            item_product = "filled-proto-tholins-vessel",
+            item_product = "filled-tholins-vessel",
             amount = 1,
             icon = "__pycoalprocessinggraphics__/graphics/achievement/what-do-you-mean-i-didnt-win-the-game.png",
             icon_size = 128,
-            limited_to_one_game = true
+            limited_to_one_game = false
         },
     }
 end
@@ -70,7 +79,7 @@ if mods.pyalienlife then
             name = "training-regimen",
             order = "0ga",
             last_hour_only = true,
-            excluded = "electric-energy-interface", -- this is NOT optional, so fill in something you can't build anyway
+            excluded = "tailings-pond", -- this is NOT optional, so fill in something that doesn't interact with power anyway
             included = "generator-1",
             minimum_energy_produced = "1TJ",
             icon = "__pycoalprocessinggraphics__/graphics/achievement/training-regimen.png",


### PR DESCRIPTION
Fixes that PV was triggered by launching a rocket. Why on earth was PV internally just a new locale slapped on the the vanilla rocket launch achievement?

This also enables other achievements that were incidentally disabled by a temp fix a year and a half ago. Some of them aren't completely finished and might need polish.