### PR TITLE
Fixed a crash when adjusting beacon in remote view

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Date: ???
   Changes:
     - Updated RU locale (Thanks, Astorin!)
     - Set minimum factorio version to 2.0.58
+    - Fixed beacon crash on changing frequency in remote view
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.40
 Date: 2025-08-12

--- a/scripts/beacons.lua
+++ b/scripts/beacons.lua
@@ -175,7 +175,7 @@ local function change_frequency(entity, new_beacon_name, player)
         }
         if player then
             --if there is no inventory attatched to the player theres no need to remove the item
-            local inventory = game.players[player].get_main_inventory(defines.inventory.character_main)
+            local inventory = game.players[player].get_main_inventory()
             if inventory then
                 inventory.remove {name = mineable_result, amount = 1}
             end

--- a/scripts/beacons.lua
+++ b/scripts/beacons.lua
@@ -174,7 +174,11 @@ local function change_frequency(entity, new_beacon_name, player)
             create_build_effect_smoke = false
         }
         if player then
-            game.players[player].get_main_inventory(defines.inventory.character_main).remove {name = mineable_result, amount = 1}
+            --if there is no inventory attatched to the player theres no need to remove the item
+            local inventory = game.players[player].get_main_inventory(defines.inventory.character_main)
+            if inventory then
+                inventory.remove {name = mineable_result, amount = 1}
+            end
         end
         -- Get new effect receivers
         for _, receiver in pairs(new_entity.get_beacon_effect_receivers()) do


### PR DESCRIPTION
Only removes the beacon from the player inventory if it exists. If no player inventory exists there is no need to remove the beacon.