### PR TITLE
Fix crashing with `ja` locale active

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ Date: ???
     - Alt+click the codex button to go directly to the T.U.R.D. page.
     - Alt+shift+click the codex button to go directly to the caravan manager.
     - Fixed typo in DE locale
+    - Fixed load issue with JA language active
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.41
 Date: 2025-08-19

--- a/locale/ja/locale.cfg
+++ b/locale/ja/locale.cfg
@@ -38,6 +38,3 @@ rocket-silo=ロケットを宇宙に打ち上げ、無重力実験を行うこ�
 [entity-name]
 
 [entity-description]
-
-
-[entity-description]


### PR DESCRIPTION
Duplicate heading made it in with the last change

Resolves pyanodon/pybugreports#1187