### PR TITLE
Improved generator autofill to evenly distribute stacks of fuels.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Date: ???
     - Alt+shift+click the codex button to go directly to the caravan manager.
     - Fixed typo in DE locale
     - Fixed load issue with JA language active
+    - Improved generator autofill to evenly distribute stacks of fuels. Resolves https://github.com/pyanodon/pybugreports/issues/1085
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.41
 Date: 2025-08-19

--- a/scripts/generator-equipment-autofill.lua
+++ b/scripts/generator-equipment-autofill.lua
@@ -49,7 +49,7 @@ local function restock_generator_equipment(player)
             ::again::
             local inserted_some = false
             for i = 1, burner_count do
-                local index = (i + burner_index_offset) % burner_count
+                local index = ((i + burner_index_offset - 1) % (burner_count)) + 1
                 local burner_data = burners[index]
                 if burner_data.fuel_categories[prototypes.item[item_stack.name].fuel_category] then
                     local item_stack_size = prototypes.item[item_stack.name].stack_size

--- a/scripts/generator-equipment-autofill.lua
+++ b/scripts/generator-equipment-autofill.lua
@@ -8,53 +8,104 @@ local function restock_generator_equipment(player)
     if not grid then return end
     local inventory = player.get_main_inventory()
     if not inventory then return end
+    local burners = {}
+    local burner_count = 0
 
     for _, equipment in pairs(grid.equipment) do
-        if equipment.type ~= "generator-equipment" then goto continue end
-        if equipment.prototype.hidden then goto continue end
-        local burner = equipment.burner
-        if not burner then goto continue end
-        local burner_inventory, burnt_result_inventory = burner.inventory, burner.burnt_result_inventory
-        if not burner_inventory then goto continue end
+        do
+            if equipment.type ~= "generator-equipment" then goto continue end
+            if equipment.prototype.hidden then goto continue end
+            local burner = equipment.burner
+            if not burner then goto continue end
+            local burner_inventory, burnt_result_inventory = burner.inventory, burner.burnt_result_inventory
+            if not burner_inventory then goto continue end
 
-        if burnt_result_inventory then
-            for i = 1, #burnt_result_inventory do
-                local stack = burnt_result_inventory[i]
-                if stack.valid_for_read then
-                    stack.count = stack.count - inventory.insert(stack)
+            if burnt_result_inventory then
+                for i = 1, #burnt_result_inventory do
+                    local stack = burnt_result_inventory[i]
+                    if stack.valid_for_read then
+                        stack.count = stack.count - inventory.insert(stack)
+                    end
                 end
             end
-        end
 
-        -- add fuel if not full
-        if not burner_inventory.is_full() then
-            for _, item_stack in pairs(inventory.get_contents()) do
-                if burner.fuel_categories[prototypes.item[item_stack.name].fuel_category] then
-                    local inserted_count = burner_inventory.insert(item_stack)
+            if not burner_inventory.is_full() then
+                -- Save for adding fuel
+                burner_count = burner_count + 1
+                burners[burner_count] = {
+                    equipment = equipment,
+                    burner_inventory = burner_inventory,
+                    fuel_categories = burner.fuel_categories,
+                }
+            end
+        end
+        ::continue::
+    end
+
+    -- add fuel if not full
+    if burner_count > 0 then
+        local burner_index_offset = 0
+        for _, item_stack in pairs(inventory.get_contents()) do
+            ::again::
+            local inserted_some = false
+            for i = 1, burner_count do
+                local index = i + burner_index_offset
+                -- Simple modulo (should only loop once normally and twice in edge case where index equals burner_index_offset and that burner is filled)
+                while index > burner_count do
+                    index = index - burner_count
+                end
+                local burner_data = burners[index]
+                if burner_data.fuel_categories[prototypes.item[item_stack.name].fuel_category] then
+                    local item_stack_size = prototypes.item[item_stack.name].stack_size
+                    local inserted_count = burner_data.burner_inventory.insert{
+                            name = item_stack.name,
+                            quality = item_stack.quality,
+                            count = math.min(item_stack.count, item_stack_size)
+                        }
                     if inserted_count ~= 0 then -- if items were inserted then remove them from the player's inventory
                         inventory.remove{
                             name = item_stack.name,
                             quality = item_stack.quality,
                             count = inserted_count
                         }
-                    end -- if now full, end early
-                    if burner_inventory.is_full() then break end
+                        -- Manually adjust item stack for iteration
+                        item_stack.count = item_stack.count - inserted_count
+                        inserted_some = true
+                    end
+                    -- if now full, remove the burner data from the list by swapping with last item
+                    if burner_data.burner_inventory.is_full() then
+                        burners[index] = burners[burner_count]
+                        burners[burner_count] = nil
+                        burner_count = burner_count - 1
+                    end
+                    -- if all burners are full, end inventory iteration early
+                    if burner_count == 0 then break end
+                    -- If none left in the stack, move onto next inventory item, otherwise try the next burner
+                    if item_stack.count == 0 then break end
                 end
             end
 
-            if burner_inventory.is_empty() then
-                -- https://github.com/pyanodon/pybugreports/issues/877
-                pcall(
-                    player.add_custom_alert,
-                    player.character,
-                    {type = "virtual", name = "no-fuel"},
-                    {"alerts.equipment-out-of-fuel", equipment.prototype.take_result.name, equipment.prototype.localised_name},
-                    false
-                )
-            end
-        end
+            -- if all burners are full, end inventory iteration early
+            if burner_count == 0 then break end
 
-        ::continue::
+            -- We inserted soe of the items, but there's more we could insert. Try again
+            if inserted_some and item_stack.count ~= 0 then goto again end
+        end
+    end
+
+    -- Check remaining unfilled burners to see if any are empty
+    for _, burner_data in pairs(burners) do
+        if burner_data.burner_inventory.is_empty() then
+            -- https://github.com/pyanodon/pybugreports/issues/877
+            pcall(
+                player.add_custom_alert,
+                player.character,
+                {type = "virtual", name = "no-fuel"},
+                {"alerts.equipment-out-of-fuel", burner_data.equipment.prototype.take_result.name, burner_data.equipment.prototype.localised_name},
+                false
+            )
+            break
+        end
     end
 end
 

--- a/scripts/generator-equipment-autofill.lua
+++ b/scripts/generator-equipment-autofill.lua
@@ -77,7 +77,11 @@ local function restock_generator_equipment(player)
                     -- if all burners are full, end inventory iteration early
                     if burner_count == 0 then break end
                     -- If none left in the stack, move onto next inventory item, otherwise try the next burner
-                    if item_stack.count == 0 then break end
+                    if item_stack.count == 0 then
+                        --Update the index offset so the next burner is checked first when we loop again with the next inventory item
+                        burner_index_offset = index
+                        break
+                    end
                 end
             end
 

--- a/scripts/generator-equipment-autofill.lua
+++ b/scripts/generator-equipment-autofill.lua
@@ -12,6 +12,7 @@ local function restock_generator_equipment(player)
     local burner_count = 0
 
     for _, equipment in pairs(grid.equipment) do
+        -- This code scoped under a "do-end" so that the goto continue statement can jump to a location where there are no localy scoped variables defined (Lua limitation)
         do
             if equipment.type ~= "generator-equipment" then goto continue end
             if equipment.prototype.hidden then goto continue end

--- a/scripts/generator-equipment-autofill.lua
+++ b/scripts/generator-equipment-autofill.lua
@@ -49,11 +49,7 @@ local function restock_generator_equipment(player)
             ::again::
             local inserted_some = false
             for i = 1, burner_count do
-                local index = i + burner_index_offset
-                -- Simple modulo (should only loop once normally and twice in edge case where index equals burner_index_offset and that burner is filled)
-                while index > burner_count do
-                    index = index - burner_count
-                end
+                local index = (i + burner_index_offset) % burner_count
                 local burner_data = burners[index]
                 if burner_data.fuel_categories[prototypes.item[item_stack.name].fuel_category] then
                     local item_stack_size = prototypes.item[item_stack.name].stack_size

--- a/scripts/generator-equipment-autofill.lua
+++ b/scripts/generator-equipment-autofill.lua
@@ -105,7 +105,6 @@ local function restock_generator_equipment(player)
                 {"alerts.equipment-out-of-fuel", burner_data.equipment.prototype.take_result.name, burner_data.equipment.prototype.localised_name},
                 false
             )
-            break
         end
     end
 end


### PR DESCRIPTION
Resolves https://github.com/pyanodon/pybugreports/issues/1085

Code is more complex for sure, but this seems to be as similarly efficient as the current implementation. It loops the inventory at most once, checking each non-full generator once per # of item / max stack size of that item. That's a little worse but hard to avoid if we want to distribute evenly. And in some cases it may perform better.
Filtered slots are respected, but not prioritised. Empty warning still works.
Tested semi-well. But can't say I've found every edge case.

As a follow up I can improve the efficiency (but slightly more complex code again) by merging the fuel category checks into a single check and then doing a first pass. When there's a lot of generators and a lot of non-fuel inventory this should help reduce the checks a lot. But I don't want to overoptimize for no reason.