### PR TITLE
Fix infinite? migration with very large amounts of hidden spoiling items

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 3.0.43
 Date: ???
   Changes:
     - Many typos fixed and some new translations in DE locale.
+    - Fix lockup trying to calculate spoilage possibilities of hidden items.
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.42
 Date: 2025-08-23

--- a/scripts/wiki/spreadsheet-pages.lua
+++ b/scripts/wiki/spreadsheet-pages.lua
@@ -420,6 +420,8 @@ local function generate_decay_spreadsheet_data(required_science)
     for name, item in pairs(prototypes.item) do
         local decay_ticks = item.get_spoil_ticks()
         if decay_ticks == 0 then goto continue end
+        -- TODO: Figure out why this is so damn slow. Dancing miku will consistently freeze migrations without this check.
+        if item.hidden then goto continue end
 
 
 
@@ -456,7 +458,6 @@ end
 
 py.on_event(py.events.on_init(), function()
     local required_science = calculate_required_science()
-
     generate_fluid_spreadsheet_data(required_science)
     generate_soild_fuel_spreadsheet_data(required_science)
     generate_decay_spreadsheet_data(required_science)


### PR DESCRIPTION
Eating all your CPU trying to make a spreadsheet of all the spoilage possibilities that Dancing Miku provides