### PR TITLE
rich text toggle

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Date: ???
     - Fix lockup trying to calculate spoilage possibilities of hidden items.
     - Improved generator autofill to evenly distribute stacks of fuels. Resolves https://github.com/pyanodon/pybugreports/issues/1085
     - Added Dutch locale
+    - Allowed codex pages to use a rich text setting other than highlight
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.42
 Date: 2025-08-23

--- a/scripts/wiki/wiki.lua
+++ b/scripts/wiki/wiki.lua
@@ -218,7 +218,7 @@ function Wiki.open_page(player, index)
     if page_data.text_only then
         local label = contents.add {type = "label", caption = {"pywiki-descriptions." .. page_data.name}, style = "label_with_left_padding", ignored_by_interaction = false}
         label.style.single_line = false
-        label.style.rich_text_setting = defines.rich_text_setting.highlight
+        label.style.rich_text_setting = page_data.rich_text_setting or defines.rich_text_setting.highlight
     elseif page_data.remote then
         remote.call(page_data.remote[1], page_data.remote[2], contents, player)
     end


### PR DESCRIPTION
added an optional field to specify the rich_text_setting on codex pages. If not specified the default is highlight