### PR TITLE
Fix autotech issue

### DIFF
--- a/prototypes/recipes/recipes.lua
+++ b/prototypes/recipes/recipes.lua
@@ -416,7 +416,7 @@ RECIPE {
     },
     results = {
         {type = "item",  name = "lime",           amount = 10},
-        {type = "fluid", name = "carbon-dioxide", amount = 100}
+        {type = "fluid", name = "carbon-dioxide", amount = 100, autotech_is_not_primary_source = true}
     },
     main_product = "lime"
 }:add_unlock("separation")


### PR DESCRIPTION
Fixes Moss and Moondrops depending on Concrete because of the Carbon Dioxide byproduct of Lime, despite Coal Processing 1 already unlocking a Carbon Dioxide recipe and being an indirect dependency of Concrete by itself