### PR TITLE
duplicate entry of "Advanced small parts" removed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ Date: ????
     - Fixed some techs having a too-fast cycle time
     - Updated Simplified Chinese locale courtesy of @alone on Discord
     - Fixed all techs added by "enable all feature flags" not being seen by autotech.
+    - duplicate entry of "Advanced small parts" in milestones removed
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.43
 Date: 2025-09-15

--- a/scripts/milestones.lua
+++ b/scripts/milestones.lua
@@ -100,7 +100,6 @@ remote.add_interface("pycoalprocessing", {
                 {type = "item",       name = "electric-engine-unit",          quantity = 1},
                 {type = "item",       name = "eg-si",                         quantity = 1},
                 {type = "item",       name = "optical-fiber",                 quantity = 1},
-                {type = "item",       name = "small-parts-02",                quantity = 1},
                 {type = "item",       name = "eva",                           quantity = 1},
                 {type = "item",       name = "pu-239",                        quantity = 1},
                 {type = "item",       name = "nuclear-sample",                quantity = 1},


### PR DESCRIPTION
The entry of "Advanced small parts" occurs twice. Removed the first one, because it should come after nylon.
<img width="400" height="165" alt="2025-09-27 10_54_26-Window" src="https://github.com/user-attachments/assets/cf14e661-b4a6-429f-922c-671309bf1c42" />
