### PR TITLE
Fix beacon-interference migration when beacon_interference_icons is nil

### DIFF
--- a/migrations/beacon-interference.lua
+++ b/migrations/beacon-interference.lua
@@ -1,4 +1,5 @@
 storage.beacon_interference_alerts = storage.beacon_interference_alerts or {}
+storage.beacon_interference_icons = storage.beacon_interference_icons or {}
 storage.alerts = storage.alerts or {}
 storage.alert_count = storage.alert_count or 0
 


### PR DESCRIPTION
This PR fixes a migration crash in migrations/beacon-interference.lua.

The migration currently initializes several storage tables defensively, but then immediately accesses storage.beacon_interference_icons without first ensuring that the table exists.

When storage.beacon_interference_icons is nil, the migration fails with:

attempt to index field 'beacon_interference_icons' (a nil value)

This PR adds the same defensive initialization pattern already used for the other storage tables:

storage.beacon_interference_icons = storage.beacon_interference_icons or {}

Background

I encountered this while updating and testing a community-maintained continuation of an abandoned compatibility mod for the latest Factorio 2.1 release.

The original compatibility mod has not been updated for newer versions of Factorio, so I created a continuation to restore compatibility with the current Py suite and another community-maintained continuation of Deadlock's Stacking Beltboxes & Compact Loaders.

As part of testing, I enabled my continuation on an existing save that already contained the latest Pyanodon mods. This changed the active mod set and caused Factorio to execute the migration contained in beacon-interference.lua.

During that migration, storage.beacon_interference_icons was nil, causing the migration to terminate with the error shown above.

Testing

I was able to reproduce the crash consistently.

After adding:

storage.beacon_interference_icons = storage.beacon_interference_icons or {}

the migration completed successfully and the save loaded normally.

I also verified that the change does not affect normal behavior when the table already exists.

Why this change is safe

This is purely a defensive initialization.

If storage.beacon_interference_icons already exists, nothing changes.

If it does not exist, the migration no longer crashes and continues as intended.